### PR TITLE
[feat] 시간별 위치 정보 저장 및 근무 시간 업데이트.받아야 할 돈 계산

### DIFF
--- a/src/main/java/org/sesac/wagekeeper/domain/company/controller/CompanyController.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/company/controller/CompanyController.java
@@ -2,11 +2,20 @@ package org.sesac.wagekeeper.domain.company.controller;
 
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.sesac.wagekeeper.domain.company.service.CompanyService;
+import org.sesac.wagekeeper.global.common.SuccessCode;
+import org.sesac.wagekeeper.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/company")
 @RestController
 public class CompanyController {
+    private final CompanyService companyService;
+    @PostMapping("/registration/{companyId}/{userId}")
+    public ResponseEntity<SuccessResponse<?>> joinCompany(@PathVariable("companyId") Long companyId, @PathVariable("userId") Long userId) {
+        companyService.joinCompany(companyId, userId);
+        return SuccessResponse.ok("");
+    }
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/company/service/CompanyService.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/company/service/CompanyService.java
@@ -1,11 +1,39 @@
 package org.sesac.wagekeeper.domain.company.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sesac.wagekeeper.domain.Util.Util;
+import org.sesac.wagekeeper.domain.company.entity.Company;
+import org.sesac.wagekeeper.domain.company.repository.CompanyRepository;
+import org.sesac.wagekeeper.domain.employmentinfo.entity.EmploymentInfo;
+import org.sesac.wagekeeper.domain.employmentinfo.repository.EmploymentInfoRepository;
+import org.sesac.wagekeeper.domain.user.entity.User;
+import org.sesac.wagekeeper.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 @Transactional
 public class CompanyService {
+    private final EmploymentInfoRepository employmentInfoRepository;
+    private final UserRepository userRepository;
+    private final CompanyRepository companyRepository;
+
+    public void joinCompany(Long companyId, Long userId) {
+        Optional<User> user = userRepository.findById(userId);
+        Optional<Company> company = companyRepository.findById(companyId);
+
+        if(user.isEmpty() || company.isEmpty()) throw new RuntimeException("No User " + userId + " or Company " + companyId);
+
+        employmentInfoRepository.save(
+                EmploymentInfo.builder()
+                        .user(user.get())
+                        .company(company.get())
+                        .salary(Util.WAGE_PER_HOUR)
+                        .time(0L)
+                        .build()
+        );
+    }
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/employmentinfo/entity/EmploymentInfo.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/employmentinfo/entity/EmploymentInfo.java
@@ -1,6 +1,8 @@
 package org.sesac.wagekeeper.domain.employmentinfo.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sesac.wagekeeper.domain.company.entity.Company;
@@ -11,6 +13,8 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(name = "employment_info")
 @Entity
 public class EmploymentInfo {

--- a/src/main/java/org/sesac/wagekeeper/domain/employmentinfo/entity/EmploymentInfo.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/employmentinfo/entity/EmploymentInfo.java
@@ -38,4 +38,8 @@ public class EmploymentInfo {
 
     private long salary;
 
+    public void increaseWorkingTime() {
+        time++;
+    }
+
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/employmentinfo/repository/EmploymentInfoRepository.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/employmentinfo/repository/EmploymentInfoRepository.java
@@ -1,7 +1,11 @@
 package org.sesac.wagekeeper.domain.employmentinfo.repository;
 
 import org.sesac.wagekeeper.domain.employmentinfo.entity.EmploymentInfo;
+import org.sesac.wagekeeper.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EmploymentInfoRepository extends JpaRepository<EmploymentInfo, Long> {
+    Optional<EmploymentInfo> findByUser(User user);
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/user/controller/UserController.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/controller/UserController.java
@@ -30,15 +30,7 @@ public class UserController {
 
     @GetMapping("/info/salary/{userId}")
     public ResponseEntity<SuccessResponse<?>> getMoneyToReceive(@PathVariable("userId") Long userId) {
-        int workingTime = 200;
-        return SuccessResponse.ok(
-                MoneyToReceive.builder()
-                        .userId(userId)
-                        .workingTime(workingTime)
-                        .salary(workingTime*Util.WAGE_PER_HOUR)
-                        .salaryToDollar((int)(workingTime*Util.WAGE_PER_HOUR* Util.EXCHANGE_RATE))
-                        .build()
-
-        );
+        MoneyToReceive moneyToReceive = userService.getMoneyToReceive(userId);
+        return SuccessResponse.ok(moneyToReceive);
     }
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/user/controller/UserController.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.sesac.wagekeeper.WageKeeperApplication;
 import org.sesac.wagekeeper.domain.Util.Util;
 import org.sesac.wagekeeper.domain.user.dto.MoneyToReceive;
+import org.sesac.wagekeeper.domain.user.dto.UserInfo;
 import org.sesac.wagekeeper.domain.user.entity.User;
 import org.sesac.wagekeeper.domain.user.service.UserService;
 import org.sesac.wagekeeper.global.common.SuccessResponse;
@@ -24,8 +25,8 @@ public class UserController {
 
     @GetMapping("/info/basic/{userId}")
     public ResponseEntity<SuccessResponse<?>> getUserInfo(@PathVariable("userId") Long userId) {
-        User user = userService.getUserInfo(userId);
-        return SuccessResponse.ok(user);
+        UserInfo userInfo = userService.getUserInfo(userId);
+        return SuccessResponse.ok(userInfo);
     }
 
     @GetMapping("/info/salary/{userId}")

--- a/src/main/java/org/sesac/wagekeeper/domain/user/controller/UserController.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.sesac.wagekeeper.WageKeeperApplication;
 import org.sesac.wagekeeper.domain.Util.Util;
 import org.sesac.wagekeeper.domain.user.dto.MoneyToReceive;
+import org.sesac.wagekeeper.domain.user.dto.UserAllInfo;
 import org.sesac.wagekeeper.domain.user.dto.UserInfo;
 import org.sesac.wagekeeper.domain.user.entity.User;
 import org.sesac.wagekeeper.domain.user.service.UserService;
@@ -33,5 +34,18 @@ public class UserController {
     public ResponseEntity<SuccessResponse<?>> getMoneyToReceive(@PathVariable("userId") Long userId) {
         MoneyToReceive moneyToReceive = userService.getMoneyToReceive(userId);
         return SuccessResponse.ok(moneyToReceive);
+    }
+
+    @GetMapping("info/all/{userId}")
+    public ResponseEntity<SuccessResponse<?>> getAllInfo(@PathVariable("userId") Long userId) {
+        UserInfo userInfo = userService.getUserInfo(userId);
+        MoneyToReceive moneyToReceive = userService.getMoneyToReceive(userId);
+
+        return SuccessResponse.ok(
+                UserAllInfo.builder()
+                        .userInfo(userInfo)
+                        .moneyToReceive(moneyToReceive)
+                        .build()
+        );
     }
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/user/dto/MoneyToReceive.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/dto/MoneyToReceive.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class MoneyToReceive {
     long userId;
     int workingTime;
-    int salary;
-    int salaryToDollar;
+    int totalMoneyToGet;
+    int totalMoneyToDollar;
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/user/dto/UserAllInfo.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/dto/UserAllInfo.java
@@ -1,0 +1,13 @@
+package org.sesac.wagekeeper.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserAllInfo {
+    UserInfo userInfo;
+    MoneyToReceive moneyToReceive;
+}

--- a/src/main/java/org/sesac/wagekeeper/domain/user/dto/UserInfo.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/dto/UserInfo.java
@@ -1,4 +1,21 @@
 package org.sesac.wagekeeper.domain.user.dto;
 
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
 public class UserInfo {
+    private Long id;
+
+    private String name;
+
+    private String comeFrom;
+
+    private Boolean submissionHistory;  //진정서류 접수 이력
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/user/dto/UserInfo.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/dto/UserInfo.java
@@ -1,0 +1,4 @@
+package org.sesac.wagekeeper.domain.user.dto;
+
+public class UserInfo {
+}

--- a/src/main/java/org/sesac/wagekeeper/domain/user/service/UserService.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/service/UserService.java
@@ -1,6 +1,10 @@
 package org.sesac.wagekeeper.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sesac.wagekeeper.domain.Util.Util;
+import org.sesac.wagekeeper.domain.employmentinfo.entity.EmploymentInfo;
+import org.sesac.wagekeeper.domain.employmentinfo.repository.EmploymentInfoRepository;
+import org.sesac.wagekeeper.domain.user.dto.MoneyToReceive;
 import org.sesac.wagekeeper.domain.user.entity.User;
 import org.sesac.wagekeeper.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -13,6 +17,7 @@ import java.util.Optional;
 @Transactional
 public class UserService {
     private final UserRepository userRepository;
+    private final EmploymentInfoRepository employmentInfoRepository;
     public String setCountry(Long userId, String countryName) {
         Optional<User> user = userRepository.findById(userId);
         if(user.isEmpty()) throw new RuntimeException("No user id " + userId);
@@ -29,5 +34,31 @@ public class UserService {
         if(user.isEmpty()) throw new RuntimeException("No user id " + userId);
 
         return user.get();
+    }
+
+    public MoneyToReceive getMoneyToReceive(Long userId) {
+        Optional<User> User = userRepository.findById(userId);
+        if(User.isEmpty()) throw new RuntimeException("No user id " + userId);
+
+        Optional<EmploymentInfo> employmentInfo = employmentInfoRepository.findByUser(User.get());
+        if(employmentInfo.isEmpty()) {
+            return MoneyToReceive.builder()
+                    .userId(userId)
+                    .totalMoneyToGet(0)
+                    .totalMoneyToDollar(0)
+                    .workingTime(0)
+                    .build();
+        }
+
+        EmploymentInfo currEmploy = employmentInfo.get();
+
+        int totalMoneyToGet = (int)(currEmploy.getTime() * currEmploy.getSalary());
+
+        return MoneyToReceive.builder()
+                .userId(userId)
+                .workingTime((int)currEmploy.getTime())
+                .totalMoneyToGet(totalMoneyToGet)
+                .totalMoneyToDollar((int)(totalMoneyToGet * Util.EXCHANGE_RATE))
+                .build();
     }
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/user/service/UserService.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import org.sesac.wagekeeper.domain.Util.Util;
 import org.sesac.wagekeeper.domain.employmentinfo.entity.EmploymentInfo;
 import org.sesac.wagekeeper.domain.employmentinfo.repository.EmploymentInfoRepository;
 import org.sesac.wagekeeper.domain.user.dto.MoneyToReceive;
+import org.sesac.wagekeeper.domain.user.dto.UserInfo;
 import org.sesac.wagekeeper.domain.user.entity.User;
 import org.sesac.wagekeeper.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -29,11 +30,18 @@ public class UserService {
         return currUser.getComeFrom();
     }
 
-    public User getUserInfo(Long userId) {
+    public UserInfo getUserInfo(Long userId) {
         Optional<User> user = userRepository.findById(userId);
         if(user.isEmpty()) throw new RuntimeException("No user id " + userId);
 
-        return user.get();
+        User currUser = user.get();
+
+        return UserInfo.builder()
+                .id(currUser.getId())
+                .name(currUser.getName())
+                .comeFrom(currUser.getComeFrom())
+                .submissionHistory(currUser.getSubmissionHistory())
+                .build();
     }
 
     public MoneyToReceive getMoneyToReceive(Long userId) {

--- a/src/main/java/org/sesac/wagekeeper/domain/workinglog/controller/WorkingLogController.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/workinglog/controller/WorkingLogController.java
@@ -2,6 +2,13 @@ package org.sesac.wagekeeper.domain.workinglog.controller;
 
 
 import lombok.RequiredArgsConstructor;
+import org.sesac.wagekeeper.domain.workinglog.dto.WorkingLogFromClient;
+import org.sesac.wagekeeper.domain.workinglog.service.WorkingLogService;
+import org.sesac.wagekeeper.global.common.SuccessCode;
+import org.sesac.wagekeeper.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/workinglog")
 @RestController
 public class WorkingLogController {
+    private final WorkingLogService workingLogService;
+    @PostMapping("/generation")
+    public ResponseEntity<SuccessResponse<?>> makeLog(@RequestBody WorkingLogFromClient workingLogFromClient) {
+        workingLogService.makeLog(workingLogFromClient);
+        return SuccessResponse.ok("");
+    }
 }

--- a/src/main/java/org/sesac/wagekeeper/domain/workinglog/dto/WorkingLogFromClient.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/workinglog/dto/WorkingLogFromClient.java
@@ -1,0 +1,12 @@
+package org.sesac.wagekeeper.domain.workinglog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class WorkingLogFromClient {
+    private Long userId;
+    private String location;
+}

--- a/src/main/java/org/sesac/wagekeeper/domain/workinglog/entity/WorkingLog.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/workinglog/entity/WorkingLog.java
@@ -1,6 +1,8 @@
 package org.sesac.wagekeeper.domain.workinglog.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sesac.wagekeeper.domain.employmentinfo.entity.EmploymentInfo;
@@ -9,6 +11,8 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(name = "working_log")
 @Entity
 public class WorkingLog {

--- a/src/main/java/org/sesac/wagekeeper/domain/workinglog/service/WorkingLogService.java
+++ b/src/main/java/org/sesac/wagekeeper/domain/workinglog/service/WorkingLogService.java
@@ -1,11 +1,53 @@
 package org.sesac.wagekeeper.domain.workinglog.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sesac.wagekeeper.domain.employmentinfo.entity.EmploymentInfo;
+import org.sesac.wagekeeper.domain.employmentinfo.repository.EmploymentInfoRepository;
+import org.sesac.wagekeeper.domain.user.entity.User;
+import org.sesac.wagekeeper.domain.user.repository.UserRepository;
+import org.sesac.wagekeeper.domain.workinglog.dto.WorkingLogFromClient;
+import org.sesac.wagekeeper.domain.workinglog.entity.WorkingLog;
+import org.sesac.wagekeeper.domain.workinglog.repository.WorkingLogRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 @Transactional
 public class WorkingLogService {
+    private final EmploymentInfoRepository employmentInfoRepository;
+    private final UserRepository userRepository;
+    private final WorkingLogRepository workingLogRepository;
+
+    public void makeLog(WorkingLogFromClient workingLogFromClient) {
+        Long currUserId = workingLogFromClient.getUserId();
+        Optional<User> user = userRepository.findById(currUserId);
+        if(user.isEmpty()) throw new RuntimeException("No User Id " + currUserId);
+
+        Optional<EmploymentInfo> safeemploymentInfo = employmentInfoRepository.findByUser(user.get());
+        if(safeemploymentInfo.isEmpty()) throw new RuntimeException("There is no record of joining the company.");
+
+        EmploymentInfo employmentInfo = safeemploymentInfo.get();
+
+        boolean isInWorking = compWithCompanyLocation(employmentInfo, workingLogFromClient.getLocation());
+        if(isInWorking) employmentInfo.increaseWorkingTime();
+
+        employmentInfoRepository.save(employmentInfo);
+
+        workingLogRepository.save(
+                WorkingLog.builder()
+                        .timestamp(LocalDateTime.now())
+                        .location(workingLogFromClient.getLocation())
+                        .employmentInfo(employmentInfo)
+                        .isWorkspace(isInWorking)
+                        .build()
+        );
+    }
+
+    private boolean compWithCompanyLocation(EmploymentInfo employmentInfo, String userLocation) {
+        return userLocation.equals(employmentInfo.getCompany().getAddress());
+    }
 }


### PR DESCRIPTION
## Related Issue ✨️

- close : #6 

## Summary ✨️
- 시간별로 사용자 위치 정보 저장
- 위치 정보와 회사 위치를 비교해 근무 시간 업데이트
- 근무시간을 이용해 사용자의 총 근무 시간과 받아야 할 돈 계산
- 사용자의 기본 정보를 제공하는 api가 문제가 있어 수정
- 사용자의 기본 정보와 받아야 할 돈을 한번에 보여주는 api 개발

## Before i request PR review ✨️
일단 저번에 얘기한데로 한 사람당 회사 한개만 등록하는걸 전제로 만들었습니다.
그런데 이러면 employmentInfo가 필요가 없었겠네요
회사 정보는 미리 DB에 저장해야 합니다.
그리고 위치 정보를 처음에 도로명 주소 생각해서 그냥 string으로 했는데
<img width="987" alt="image" src="https://github.com/user-attachments/assets/a90c1cde-813d-4502-833f-abe4aced403a">
위도 경도로 해야 한다고 해서 일단 사진처럼 /로 구분하도록 했습니다. 이러면 백이나 프론트에서 파싱을 해서 써야겠네여...
